### PR TITLE
fix: resolve menu display issue behind components(#18)

### DIFF
--- a/src/app/modules/layout/components/navbar/navbar-menu/navbar-menu.component.html
+++ b/src/app/modules/layout/components/navbar/navbar-menu/navbar-menu.component.html
@@ -11,7 +11,7 @@
   </button>
   <!-- Dropdown  -->
   <div
-    class="dropdown-content absolute top-[100%] min-w-[200px] origin-top-left"
+    class="dropdown-content absolute top-[100%] min-w-[200px] origin-top-left z-10"
     navbar-submenu
     [submenu]="menu.items"></div>
 </div>


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/68da2dae-d2aa-43a6-a9c1-1baeb43fe2c8)


Closes #18: This pull request resolves the issue with the menu displaying behind main components by adjusting the `z-index`.

