### PR TITLE
chore: remove zone.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2025-10-11
+
+### removed
+
+- remove zoneless change detection
+
 ## [0.10.1] - 2025-02-09
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,7 @@
         "ng-apexcharts": "^1.7.1",
         "ngx-sonner": "^2.0.1",
         "rxjs": "^7.8.2",
-        "tslib": "^2.3.0",
-        "zone.js": "~0.15.0"
+        "tslib": "^2.3.0"
       },
       "devDependencies": {
         "@angular/build": "^20.0.1",
@@ -12153,7 +12152,9 @@
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
       "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     }
   },
   "dependencies": {
@@ -19833,7 +19834,9 @@
     "zone.js": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.0.tgz",
-      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA=="
+      "integrity": "sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==",
+      "optional": true,
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-tailwind",
   "displayName": "Angular Tailwind",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "description": "Angular & Tailwind CSS Admin Dashboard Starter Kit, Free and Open Source",
   "homepage": "https://github.com/lannodev/angular-tailwind#readme",
   "repository": {
@@ -49,8 +49,7 @@
     "ng-apexcharts": "^1.7.1",
     "ngx-sonner": "^2.0.1",
     "rxjs": "^7.8.2",
-    "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
     "@angular/build": "^20.0.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,11 @@
 import { enableProdMode, importProvidersFrom } from '@angular/core';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
-import { environment } from './environments/environment';
-import { AppComponent } from './app/app.component';
-import { AppRoutingModule } from './app/app-routing.module';
 import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { AppRoutingModule } from './app/app-routing.module';
+import { AppComponent } from './app/app.component';
+import { environment } from './environments/environment';
+import { provideZonelessChangeDetection } from '@angular/core';
 
 if (environment.production) {
   enableProdMode();
@@ -16,7 +16,11 @@ if (environment.production) {
 }
 
 bootstrapApplication(AppComponent, {
-  providers: [importProvidersFrom(BrowserModule, AppRoutingModule), provideAnimations()],
+  providers: [
+    importProvidersFrom(BrowserModule, AppRoutingModule),
+    provideAnimations(),
+    provideZonelessChangeDetection(),
+  ],
 }).catch((err) => console.error(err));
 
 function selfXSSWarning() {

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -45,7 +45,7 @@
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */
-import 'zone.js' // Included with Angular CLI.
+//import 'zone.js' // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,8 +1,7 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/testing'
-import { getTestBed } from '@angular/core/testing'
-import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing'
+import { getTestBed } from '@angular/core/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting())
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());


### PR DESCRIPTION
with the latest versions of Angular, it’s finally possible to fully disable Zone.js and switch the entire app to Signal-based Change

#45